### PR TITLE
release-gh-notes: add optional commit param

### DIFF
--- a/.github/workflows/release-gh-notes.yml
+++ b/.github/workflows/release-gh-notes.yml
@@ -11,6 +11,10 @@ on:
         required: true
         description: npm package of the release
         type: string
+      commit:
+        required: false
+        description: commit to generate release notes
+        type: string
 
 jobs:
   release:


### PR DESCRIPTION
Backward-compatible version of #5. This does no actual changes, but allows the new param in the job



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
