### PR TITLE
chore: Run git-secrets as part of the build

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -27,6 +27,25 @@ permissions:
   security-events: write
 
 jobs:
+  git-secrets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code with history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 500
+
+      - name: Install git-secrets
+        run: |
+          wget -O /usr/local/bin/git-secrets https://raw.githubusercontent.com/awslabs/git-secrets/master/git-secrets
+          chmod +x /usr/local/bin/git-secrets
+          git secrets --register-aws --global
+
+      - name: Run git-secrets
+        run: git secrets --scan-history
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
*Issue #, if available:* Document `9GQ0AGFT9WdZ`

*Description of changes:*
This change runs the `git-secrets` whenever a package is built. This helps to detect accidentally committed secrets.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
