### PR TITLE
feat: Add shared visual regression tests workflow

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,59 @@
+name: Visual Regressions
+
+on:
+  workflow_call:
+    inputs:
+      repository:
+        required: true
+        type: string
+
+env:
+  VISUAL_REGRESSION_SNAPSHOT_DIRECTORY: '__image_snapshots__'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    if: github.event.ref != 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: 'Download artifacts'
+        # Turns out you can not use artifacts from a previous workflow run.
+        # I'm reluctant to check in the resulting screenshots into the repository,
+        # which is why we use the following hack, until it's solved on Github side:
+        # https://github.com/actions/download-artifact/issues/3
+        run: |
+          RUN_ID=`gh run --repo ${{ inputs.repository }} --branch main list --workflow "Visual Regressions" --json databaseId --jq .[0].databaseId`
+          echo "Downloading snapshots created in run ${RUN_ID}"
+          gh run --repo ${{ inputs.repository }} download ${RUN_ID} -n "visual-regression-snapshots" -D ${{ env.VISUAL_REGRESSION_SNAPSHOT_DIRECTORY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm install
+      - run: npm run build
+      - run: npm run test:visual
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: visual-regression-snapshots-results
+          path: ${{ env.VISUAL_REGRESSION_SNAPSHOT_DIRECTORY }}
+  update:
+    name: Update Snapshots
+    runs-on: ubuntu-latest
+    if: github.event.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm install
+      - run: npm run build
+      - run: npm run test:visual:update
+      - uses: actions/upload-artifact@v3
+        with:
+          name: visual-regression-snapshots
+          path: ${{ env.VISUAL_REGRESSION_SNAPSHOT_DIRECTORY }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -27,11 +27,12 @@ jobs:
         # which is why we use the following hack, until it's solved on Github side:
         # https://github.com/actions/download-artifact/issues/3
         run: |
-          RUN_ID=`gh run --repo ${{ inputs.repository }} --branch main list --workflow "Visual Regressions" --json databaseId --jq .[0].databaseId`
+          RUN_ID=`gh run --repo $REPOSITORY --branch main list --workflow "Visual Regressions" --json databaseId --jq .[0].databaseId`
           echo "Downloading snapshots created in run ${RUN_ID}"
-          gh run --repo ${{ inputs.repository }} download ${RUN_ID} -n "visual-regression-snapshots" -D ${{ env.VISUAL_REGRESSION_SNAPSHOT_DIRECTORY }}
+          gh run --repo $REPOSITORY download ${RUN_ID} -n "visual-regression-snapshots" -D $VISUAL_REGRESSION_SNAPSHOT_DIRECTORY
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ inputs.repository }}
       - run: npm install
       - run: npm run build
       - run: npm run test:visual


### PR DESCRIPTION
*Description of changes:*

Add shared visual regression tests workflow (currently being used by code-view and board-components).

Respective PRs:
https://github.com/cloudscape-design/board-components/pull/291
https://github.com/cloudscape-design/code-view/pull/12

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
