### PR TITLE
chore: remove scripts for all packages being published

### DIFF
--- a/.github/actions/release-package/index.mjs
+++ b/.github/actions/release-package/index.mjs
@@ -25,6 +25,9 @@ function releasePackage(packagePath) {
   const packageJson = JSON.parse(readFileSync(packageJsonPath));
   packageJson.version += inputs.suffix;
 
+  // Remove lifecycle scripts as they were already run before
+  packageJson.scripts = {};
+
   // Add internal folder to files in package.json
   if (packageJson.files) {
     packageJson.files.push(internalFolderName);


### PR DESCRIPTION
## Notes

Remove code duplication. Currently we repeat this removal in several places:

https://github.com/cloudscape-design/board-components/blob/d5dd6dcc1629ae93134d934bf8ba648fb4b2d594/scripts/package-json.js#L15

https://github.com/cloudscape-design/code-view/blob/82b17cfb756d36582971c31b1c1fb91de7c910a8/scripts/package-json.js#L15

(other packages also do that but more obscure)

## Testing

Tested in this run: https://github.com/cloudscape-design/board-components/actions/runs/7864470510


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
