### PR TITLE
disable husky in CI environment

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -26,6 +26,11 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  # Disable Husky in CI
+  # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+  HUSKY: 0
+
 jobs:
   git-secrets:
     runs-on: ubuntu-latest

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -15,6 +15,12 @@ defaults:
   run:
     shell: bash
 
+
+env:
+  # Disable Husky in CI
+  # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+  HUSKY: 0
+
 jobs:
   buildJestPreset:
     name: Build jest-preset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  # Disable Husky in CI
+  # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+  HUSKY: 0
+
 jobs:
   release:
     concurrency: release-${{ github.ref }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixing this error: https://github.com/cloudscape-design/board-components/actions/runs/7864468231/job/21456319489#step:3:618

```
npm ERR! husky - .git can't be found (see https://typicode.github.io/husky/#/?id=custom-directory)
```

This happens when running `npm pack` or `npm publish` for artifacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
