### PR TITLE
chore: Remove usage of set-output

### DIFF
--- a/.github/workflows/release-gh-notes.yml
+++ b/.github/workflows/release-gh-notes.yml
@@ -30,7 +30,7 @@ jobs:
         run: npx conventional-changelog-cli@2 -i CHANGELOG.md -s -p conventionalcommits
       - name: Get number of lines in CHANGELOG.md
         id: changelog
-        run: echo ::set-output name=changelog_lines::$(wc -l < "CHANGELOG.md")
+        run: echo "changelog_lines=$(wc -l < "CHANGELOG.md" | sed  s/\ //g)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Add empty release note
         run: echo "No customer visible changes in this release" >> CHANGELOG.md


### PR DESCRIPTION
*Description of changes:*
This has been deprecated by GitHub actions. Change to recommended usage.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

*Testing:*
Not sure how to safely test this change. Looking for suggestions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
