### PR TITLE
chore: Update build package logic for refactored test-utils

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -80,7 +80,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.package }}
       run: |
-        cd packages/core
+        cd lib/core
         npm pack
         cp *-test-utils-core-*.tgz $GITHUB_WORKSPACE
         cd ../converter

--- a/.github/actions/patch-local-dependencies/utils.mjs
+++ b/.github/actions/patch-local-dependencies/utils.mjs
@@ -69,14 +69,6 @@ function updateDependencyVersions(dependencies, newVersion, sourcePackageName) {
         return;
       }
 
-      // Don't touch this local lerna dependency in test-utils-converter
-      if (
-        sourcePackageName === '@cloudscape-design/test-utils-converter' &&
-        packageName === '@cloudscape-design/test-utils-core'
-      ) {
-        return;
-      }
-
       const nextVersion = typeof newVersion === 'function' ? newVersion(packageName) : newVersion;
 
       if (isPackageLock) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Test utils are recently refactored in this [commit](https://github.com/cloudscape-design/test-utils/commit/0b34fbbf8bee502962e4221965cf9465e7d8b085) where the artifacts now found in the lib folder. Lerna was also removed so we can also remove any special treatment there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
