### PR TITLE
chore: Publish browser test tools lib folder

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -60,7 +60,7 @@ runs:
       run: npm test
       working-directory: ${{ inputs.package }}
     - name: Pack artifacts (lib folder)
-      if: ${{ inputs.package == 'component-toolkit' }}
+      if: ${{ inputs.package == 'component-toolkit' || inputs.package == 'browser-test-tools' }}
       shell: bash
       working-directory: ${{ inputs.package }}
       run: |
@@ -68,7 +68,7 @@ runs:
         npm pack
         cp *-${{ inputs.package }}-*.tgz $GITHUB_WORKSPACE/${{ inputs.package }}.tgz
     - name: Pack artifacts (root folder)
-      if: ${{ inputs.package == 'browser-test-tools' || inputs.package == 'collection-hooks' || inputs.package == 'documenter' || inputs.package == 'global-styles' || inputs.package == 'jest-preset' }}
+      if: ${{ inputs.package == 'collection-hooks' || inputs.package == 'documenter' || inputs.package == 'global-styles' || inputs.package == 'jest-preset' }}
       shell: bash
       working-directory: ${{ inputs.package }}
       run: |

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -15,7 +15,6 @@ defaults:
   run:
     shell: bash
 
-
 env:
   # Disable Husky in CI
   # https://typicode.github.io/husky/how-to.html#ci-server-and-docker


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes browser-test-tools package to release out of the lib folder. The [browser test tools PR](https://github.com/cloudscape-design/browser-test-tools/pull/77) dry-run relies on this change to be merged before it can pass. The change has been tested against this branch and passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
