### PR TITLE
setup dry-run for code view component

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -107,8 +107,8 @@ runs:
         mv *-theming-build-*.tgz theming-build.tgz
         mv *-theming-runtime-*.tgz theming-runtime.tgz
 
-    - name: Package board components files
-      if: ${{ inputs.package == 'board-components' }}
+    - name: Package generic components packages
+      if: ${{ inputs.package == 'board-components' || inputs.package == 'code-view' }}
       shell: bash
       working-directory: ${{ inputs.package }}
       run: |

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -128,6 +128,26 @@ jobs:
           package: board-components
           download_dependencies: true
 
+  buildCodeView:
+    name: Build code view components
+    runs-on: ubuntu-latest
+    needs:
+      - buildGlobalStyles
+      - buildBrowserTestTools
+      - buildDocumenter
+      - buildTestUtils
+      - buildComponentToolkit
+      - buildComponents
+    steps:
+      - name: Download component artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: components-package
+      - uses: cloudscape-design/actions/.github/actions/build-package@main
+        with:
+          package: code-view
+          download_dependencies: true
+
   unitTest:
     name: Components unit tests
     runs-on: ubuntu-latest
@@ -221,6 +241,7 @@ jobs:
     needs:
       - buildComponents
       - buildBoardComponents
+      - buildCodeView
       - buildBrowserTestTools
       - buildCollectionHooks
       - buildTestUtils


### PR DESCRIPTION
*Issue #, if available:*

Code view package should be a first class of our build workflows

*Description of changes:*

Tested in a manual workflow run: https://github.com/cloudscape-design/actions/actions/runs/8252362525

Dry-run in this PR is expected to fail, because it still uses the mainline workflow definitions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
