### PR TITLE
remove force flag from installation workflows

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -47,7 +47,7 @@ runs:
 
     - name: npm install
       shell: bash
-      run: npm i --force
+      run: npm install
       working-directory: ${{ inputs.package }}
     - name: Build
       if: ${{ inputs.skip_build != 'true' }}

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -61,7 +61,7 @@ jobs:
           node-version: 18
       - name: Unlock dependencies
         uses: cloudscape-design/actions/.github/actions/unlock-dependencies@main
-      - run: npm i --force
+      - run: npm install
       - run: npm run build
       - run: npm run lint
       - run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: 18
 
-      - run: npm install --force
+      - run: npm install
 
       - run: npm run build
 


### PR DESCRIPTION
*Issue #, if available:*

After https://github.com/cloudscape-design/components/pull/2071 we should now use strict `npm install` in our builds to ensure that we are not throwing unexpected warnings anywhere to our customers

*Description of changes:*

Created a dry-run in a separate branch:
https://github.com/cloudscape-design/actions/actions/runs/8341382193

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
