### PR TITLE
chore: Upgrade codecov to v4

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -76,7 +76,7 @@ jobs:
           name: ${{ inputs.artifact-name }}
       - name: Codecov
         if: ${{ inputs.skip-codecov == false && always() }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
*Description of changes:*
With the requirement of the CODECOV token PRs from forked repositories can no longer run this action. Apparently v4 allows tokenless contributions for this case.

---

https://github.com/codecov/codecov-action
v4 Release
v4 of the Codecov GitHub Action will use the [Codecov CLI](https://github.com/codecov/codecov-cli) to upload coverage reports to Codecov.

Breaking Changes
Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless (e.g. contributors to OS projects do not need the upstream repo's Codecov token)
Various arguments to the Action have been removed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
