### PR TITLE
chore: Update actions/upload-artifact to v4

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -119,7 +119,7 @@ runs:
         tar -czf ../design-tokens.tgz --directory=lib/design-tokens .
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.target_artifact }}
         path: ${{ inputs.artifact_path || format('{0}*.tgz', inputs.package) }}

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -18,7 +18,7 @@ runs:
         tar -zcvf ${{ inputs.name }}.tar.gz ${{ inputs.path }}
       shell: bash
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.name }}.tar.gz


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
v3 of upload-artifacts uses node 16 which is EOL while v4 uses node 20

Errors being shown in dry-runs:

"Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/."

v4 also brings [improvements](https://github.com/actions/upload-artifact?tab=readme-ov-file#improvements)

We also already use it in the [release](https://github.com/cloudscape-design/actions/blob/main/.github/workflows/release.yml#L42) workflow so it seems to work fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
