### PR TITLE
chore: Don't fail lint-pr workflow outside pull_request trigger

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -13,8 +13,14 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const title = context.payload.pull_request.title;
+            const pullRequest = context.payload.pull_request;
 
+            if(!pullRequest) {
+              return;
+            }
+
+            const title = pullRequest.title;
+            
             const allowedTypes = ["chore", "feat", "fix", "refactor", "test", "revert"];
 
             const matchesType = allowedTypes.some( type => title.startsWith(type + ":") );


### PR DESCRIPTION
*Description of changes:*

Currently we only call `lint-pr` workflow on pull request events where PR payload is available in github action event, to support merge queue feature all required checks in PR must run on merge queue events where the PR payload is not available in merge group event.

This change allows to skip the PR title check when workflow is ran outside a PR context. 

example of a failing action https://github.com/cloudscape-design/global-styles/actions/runs/10222229620

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
