### PR TITLE
chore: Update and standardise env variables with AWSUI_ prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,17 @@ jobs:
           disable-source-override: true
           hide-cloudwatch-logs: true
           env-vars-for-codebuild: |
-            GITHUB_ARTIFACT_ID,
-            GITHUB_REPOSITORY_NAME,
-            GITHUB_COMMIT_MESSAGE,
-            GITHUB_TOKEN
+            AWSUI_GITHUB_ARTIFACT_ID,
+            AWSUI_GITHUB_BRANCH_NAME,
+            AWSUI_GITHUB_COMMIT_SHA,
+            AWSUI_GITHUB_COMMIT_MESSAGE,
+            AWSUI_GITHUB_REPOSITORY_NAME,
+            AWSUI_GITHUB_TOKEN
         env:
-          GITHUB_ARTIFACT_ID: ${{ steps.upload-release.outputs.artifact-id }}
-          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
-          GITHUB_COMMIT_MESSAGE: ${{ github.event.commits[0].message }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWSUI_GITHUB_ARTIFACT_ID: ${{ steps.upload-release.outputs.artifact-id }}
+          AWSUI_GITHUB_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          AWSUI_GITHUB_COMMIT_SHA: ${{ github.event.commits[0].sha }}
+          AWSUI_GITHUB_COMMIT_MESSAGE: ${{ github.event.commits[0].message }}
+          AWSUI_GITHUB_REPOSITORY_NAME: ${{ github.event.repository.full_name }}
+          AWSUI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
*Description of changes:*
Second attempt at this change: https://github.com/cloudscape-design/actions/commit/f2016f393421ed11f87b80e3f5a6d459f4f4da00

Tested via the actions this time. The needed change is to use the `full_name` which send the repository name with the owner. e.g. `@cloudscape-design/jest-prest`

Before:
```
AWSUI_GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }} -> jest-preset
```

After:
```
AWSUI_GITHUB_REPOSITORY_NAME: ${{ github.event.repository.full_name }} -> @cloudscape-design/jest-preset
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
