### PR TITLE
chore: Update to v4 of actions/download-artifact and actions/upload-artifact for all workflows except dry-run

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Download artifacts
       if: ${{ inputs.download_dependencies == 'true' }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: dependencies
 
@@ -119,7 +119,7 @@ runs:
         tar -czf ../design-tokens.tgz --directory=lib/design-tokens .
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.target_artifact }}
         path: ${{ inputs.artifact_path || format('{0}*.tgz', inputs.package) }}

--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -18,7 +18,7 @@ runs:
         tar -zcvf ${{ inputs.name }}.tar.gz ${{ inputs.path }}
       shell: bash
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.name }}.tar.gz


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The title says it all. Upgrading the dry-run workflow is not straight-forward because of this breaking change: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact.

Here's a test PR in the components repo to verify that this commit doesn't break anything: https://github.com/cloudscape-design/components/pull/2645

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
