### PR TITLE
chore: Upgrade to node 20

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -28,9 +28,9 @@ runs:
         repository: cloudscape-design/${{ inputs.package }}
         path: ${{ inputs.package }}
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
 
     - name: Download artifacts
       if: ${{ inputs.download_dependencies == 'true' }}

--- a/.github/actions/patch-local-dependencies/action.yml
+++ b/.github/actions/patch-local-dependencies/action.yml
@@ -12,8 +12,8 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
     - run: INPUT_PATH=${{ inputs.path }} INPUT_TYPE=${{ inputs.type }} node ${{ github.action_path }}/local.mjs
       shell: bash

--- a/.github/actions/unlock-dependencies/action.yml
+++ b/.github/actions/unlock-dependencies/action.yml
@@ -5,8 +5,8 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
     - run: node ${{ github.action_path }}/index.js
       shell: bash

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -56,9 +56,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Unlock dependencies
         uses: cloudscape-design/actions/.github/actions/unlock-dependencies@main
       - run: npm install

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -186,9 +186,9 @@ jobs:
       - buildComponents
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Download component artifacts
         uses: actions/download-artifact@v3
         with:
@@ -208,9 +208,9 @@ jobs:
       - buildComponents
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Download component artifacts
         uses: actions/download-artifact@v3
         with:
@@ -235,9 +235,9 @@ jobs:
       - buildComponents
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Download component artifacts
         uses: actions/download-artifact@v3
         with:
@@ -265,9 +265,9 @@ jobs:
       - buildComponents
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Download component artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - run: npm install
       - run: npm run build


### PR DESCRIPTION
### Description of changes
Node 18 is out of active support and current actions are encouraged to upgrade away.

### How has this been tested?
1. Created [node20 branch](https://github.com/cloudscape-design/actions/tree/node20) which points all actions to `@node20` of the actions package. 
2. Created test branches on consuming packages to validate dry-run and release targets still work as expected

- [components draft PR against branch](https://github.com/cloudscape-design/components/pull/2920)
    - [build job](https://github.com/cloudscape-design/components/actions/runs/11459053773/job/31882740908?pr=2920)
    - [dry-run](https://github.com/cloudscape-design/components/actions/runs/11459053756?pr=2920)
- [components release job](https://github.com/cloudscape-design/components/actions/runs/11459123656)  

Build Job log
![image](https://github.com/user-attachments/assets/874dacb1-5f52-40b5-8e7b-b0580b5577b7)


*Issue #, if available:* 
AWSUI-59859

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
