### PR TITLE
chore: Add custom dry-runs for specific packages

### DIFF
--- a/.github/workflows/dry-run-board-components.yml
+++ b/.github/workflows/dry-run-board-components.yml
@@ -1,0 +1,40 @@
+# This workflow executes a custom dry-run for the board-components-package
+name: dry-run
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # Disable Husky in CI
+  # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+  HUSKY: 0
+
+jobs:
+  buildBoardComponents:
+    name: Build board components
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cloudscape-design/actions/.github/actions/build-repository@main
+        with:
+          repository: cloudscape-design/board-components
+
+  demosTest:
+    name: Demos tests
+    runs-on: ubuntu-latest
+    needs:
+      - buildBoardComponents
+    steps:
+      - name: Build
+        uses: cloudscape-design/actions/.github/actions/build-repository@main
+        with:
+          repository: cloudscape-design/demos

--- a/.github/workflows/dry-run-chat-components.yml
+++ b/.github/workflows/dry-run-chat-components.yml
@@ -1,0 +1,40 @@
+# This workflow executes a custom dry-run for chat board-components-package
+name: dry-run
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # Disable Husky in CI
+  # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+  HUSKY: 0
+
+jobs:
+  buildChatComponents:
+    name: Build chat components
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cloudscape-design/actions/.github/actions/build-repository@main
+        with:
+          repository: cloudscape-design/chat-components
+
+  demosTest:
+    name: Demos tests
+    runs-on: ubuntu-latest
+    needs:
+      - buildChatComponents
+    steps:
+      - name: Build
+        uses: cloudscape-design/actions/.github/actions/build-repository@main
+        with:
+          repository: cloudscape-design/demos

--- a/.github/workflows/dry-run-code-view.yml
+++ b/.github/workflows/dry-run-code-view.yml
@@ -1,0 +1,40 @@
+# This workflow executes a custom dry-run for chat board-components-package
+name: dry-run
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # Disable Husky in CI
+  # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+  HUSKY: 0
+
+jobs:
+  buildCodeView:
+    name: Build code view components
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cloudscape-design/actions/.github/actions/build-repository@main
+        with:
+          repository: cloudscape-design/code-view
+
+  demosTest:
+    name: Demos tests
+    runs-on: ubuntu-latest
+    needs:
+      - buildCodeView
+    steps:
+      - name: Build
+        uses: cloudscape-design/actions/.github/actions/build-repository@main
+        with:
+          repository: cloudscape-design/demos


### PR DESCRIPTION
### Description of changes
Add custom dry-runs for packages that do not need to rebuild the full tree. Changes in board-components, chat-components and code-view currently build the full dry-run tree. This is unnecessary and takes a long time due to the components build and test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
