### PR TITLE
chore: Assert shards succeed

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -231,16 +231,32 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - integTestShards
+    if: always()
     steps:
-      - run: echo "Completed all integration tests"
+      - name: Check shard status
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more shards failed"
+            exit 1
+          else
+            echo "All shards completed successfully"
+          fi
 
   a11yTest:
     name: Components accessibility tests
     runs-on: ubuntu-latest
     needs:
       - a11yTestShards
+    if: always()
     steps:
-      - run: echo "Completed all accessibility tests"
+      - name: Check shard status
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more shards failed"
+            exit 1
+          else
+            echo "All shards completed successfully"
+          fi
 
   demosTest:
     name: Demos tests


### PR DESCRIPTION
### Description of changes
If any shards fail the final job is skipped, Github considers this as [passing](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging) with regards to branch protection checks. This requires the branch protection rule to check every shard. This is mostly fine once set up as this probably won't change often.

We can also make the final job always run and then assert the shard result. This should allow the branch protection rule to reference the final job correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
