### PR TITLE
always upload build artifacts

### DIFF
--- a/.github/actions/build-repository/action.yml
+++ b/.github/actions/build-repository/action.yml
@@ -120,7 +120,7 @@ runs:
         path: lib/*.tgz
 
     - name: Upload additional artifacts
-      if: ${{ inputs.artifact-path != '' && inputs.artifact-name != '' }}
+      if: ${{ always() && inputs.artifact-path != '' && inputs.artifact-name != '' }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -6,7 +6,7 @@ on:
       skip-tests:
         required: false
         type: boolean
-        default: false    
+        default: false
       skip-codeql:
         type: boolean
         description: Skip CodeQL checks
@@ -71,7 +71,7 @@ jobs:
           artifact-path: ${{ inputs.artifact-path }}
           artifact-name: ${{ inputs.artifact-name }}
       - name: Codecov
-        if: ${{ inputs.skip-codecov == false && always() }}
+        if: ${{ inputs.skip-codecov == false }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Tune `always()` conditions

1. Run "Upload additional artifacts" even if the tests fail. Needed to see allure report for the failed builds
2. Do not run Codecov if the tests failed, it is not needed

Tested in my experimental browser-test-tools PR: https://github.com/cloudscape-design/browser-test-tools/pull/134


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
