### PR TITLE
enable lint runs

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -6,7 +6,7 @@ on:
       skip-tests:
         required: false
         type: boolean
-        default: false    
+        default: false
       skip-codeql:
         type: boolean
         description: Skip CodeQL checks
@@ -68,6 +68,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
           skip-tests: ${{ inputs.skip-tests }}
+          skip-lint: false
           artifact-path: ${{ inputs.artifact-path }}
           artifact-name: ${{ inputs.artifact-name }}
       - name: Codecov


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Because it is `true` by default, linter never runs in our PR builds


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
