### PR TITLE
update skip-lint default value

### DIFF
--- a/.github/actions/build-repository/action.yml
+++ b/.github/actions/build-repository/action.yml
@@ -7,7 +7,7 @@ inputs:
   skip-lint:
     required: false
     type: boolean
-    default: true
+    default: false
   skip-tests:
     required: false
     type: boolean

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           repository: ${{ github.repository }}
           skip-tests: ${{ inputs.skip-tests }}
-          skip-lint: false
           artifact-path: ${{ inputs.artifact-path }}
           artifact-name: ${{ inputs.artifact-name }}
       - name: Codecov


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Follow up for #71 

Turns out there are too many places where we reuse this action: https://github.com/search?q=org%3Acloudscape-design+actions%2Fbuild-repository&type=code

Updating all of them manually does not make sense. Let's change the default


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
