### PR TITLE
chore: Allow configuring the codebuild project name via secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: ${{ inputs.project-name || 'Importer-v2' }}
+          project-name: ${{ inputs.project-name || secrets.AWS_CODEBUILD_PROJECT_NAME ||  'Importer-v2' }}
           disable-source-override: true
           hide-cloudwatch-logs: true
           env-vars-for-codebuild: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allow configuring the codebuild project name via secrets. This allows changing of the role and project to point to the beta stack when needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
