### PR TITLE
chore: Add actions:read permissions to Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: read
 
 env:
   # Disable Husky in CI


### PR DESCRIPTION
This is necessary to build private repositories, otherwise the build workflow does not have the necessary access to artifacts.

Adding `actions: read` to the parent release workflow (the one that calls this one) in the private repo did not help, but by copypasting this workflow there instead of calling it did work, which indicates that the problem was that the permissions here override the ones in the parent workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
