### PR TITLE
Revert "chore: Add actions:read permissions to Release workflow (#74)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ on:
 permissions:
   id-token: write
   contents: read
-  actions: read
 
 env:
   # Disable Husky in CI


### PR DESCRIPTION
This reverts commit 63e23df0f6a0ec270e9f34e4759db8c4c709fa99 because it breaks consuming actions which do not have `actions: read` permissions ([example](https://github.com/cloudscape-design/components/actions/runs/14714641057)). For private repositories, we will have to duplicate some action code for the time being instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
