### PR TITLE
fix: Fixes workflow name for components dry-run

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -136,7 +136,7 @@ jobs:
           repository: cloudscape-design/component-toolkit
 
   buildComponents:
-    name: Build components (React ${{ matrix.react }})
+    name: Build components${{ matrix.react != 16 && format(' (React {0})', matrix.react) || '' }}
     runs-on: ubuntu-latest
     needs:
       - createBuildTree


### PR DESCRIPTION
Another small follow-up for: https://github.com/cloudscape-design/components/pull/3829

The "dry-run / Build components" name must not change for React 16 as we declare it as required in our rulesets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
