### PR TITLE
fix: Fixes test shards config

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -248,7 +248,7 @@ jobs:
       fail-fast: false
       matrix:
         react: [16, 18]
-        shard: [1, 2, 3, 4]
+        shard: ['1/4', '2/4', '3/4', '4/4']
     needs:
       # Must match the dependencies for buildComponents
       - createBuildTree
@@ -272,7 +272,7 @@ jobs:
           skip-build-artifact: true
       - name: Integration tests
         if: ${{ contains(needs.createBuildTree.outputs.repositories, 'cloudscape-design/components') }}
-        run: npm run test:integ -- --shard=${{ matrix.shard }}/${{ strategy.job-total }} --reactVersion=${{ matrix.react }}
+        run: npm run test:integ -- --shard=${{ matrix.shard }} --reactVersion=${{ matrix.react }}
 
   motionTest:
     name: Components motion tests (React ${{ matrix.react }})
@@ -310,7 +310,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [1, 2, 3, 4, 5, 6]
+        shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
     needs:
       # Must match the dependencies for buildComponents
       - createBuildTree
@@ -333,7 +333,7 @@ jobs:
           skip-build-artifact: true
       - name: Accessibility tests
         if: ${{ contains(needs.createBuildTree.outputs.repositories, 'cloudscape-design/components') }}
-        run: npm run test:a11y -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        run: npm run test:a11y -- --shard=${{ matrix.shard }}
 
   integTest:
     name: Components integration tests


### PR DESCRIPTION
We defined shards flag as such: `--shard=${{ matrix.shard }}/${{ strategy.job-total }}`. However, the `strategy.job-total` is the total number of matrix combinations. It was equal to 4 when we only had shards, and it got increased to 8 when we added react version. The fix uses explicit shard values to address the immediate problem (we only run the half of integration tests now!) and avoid the same problem from happening in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
