### PR TITLE
chore: Updates dependabot cleanup workflow to use npm i instead of ci

### DIFF
--- a/.github/workflows/dependabot-lockfile-cleanup.yml
+++ b/.github/workflows/dependabot-lockfile-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm install
 
       - name: Clean up internal dependencies from lockfile
         run: |


### PR DESCRIPTION
This should fix the following issue: https://github.com/cloudscape-design/components/actions/runs/24229768304

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
