### PR TITLE
chore: Fixes dependabot cleanup script check

### DIFF
--- a/.github/workflows/dependabot-lockfile-cleanup.yml
+++ b/.github/workflows/dependabot-lockfile-cleanup.yml
@@ -24,11 +24,7 @@ jobs:
 
       - name: Clean up internal dependencies from lockfile
         run: |
-          if ! command -v prepare-package-lock &> /dev/null; then
-            echo "prepare-package-lock not found, skipping"
-            exit 0
-          fi
-          prepare-package-lock
+          npx --no-install prepare-package-lock
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git diff --quiet || (git add package-lock.json && git commit -m "chore: remove @cloudscape-design deps from lockfile" && git push)


### PR DESCRIPTION
The dependabot cleanup workflow is meant to trigger for dependabot PRs and run the package lock cleanup script.

It was successfully called for https://github.com/cloudscape-design/components/pull/4479 (https://github.com/cloudscape-design/components/actions/workflows/dependabot-lockfile-cleanup.yml), but it did not create a new commit. The reason is the old check for the presence of the script:
```
Run if ! command -v prepare-package-lock &> /dev/null; then
prepare-package-lock not found, skipping
```

We do not actually need to check if the script is available because the workflow needs to be explicitly added to repos. It will not be added to those where the cleanup script is not avaialble.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
