### PR TITLE
chore: Fixes dependabot cleanup git scripts issue

### DIFF
--- a/.github/workflows/dependabot-lockfile-cleanup.yml
+++ b/.github/workflows/dependabot-lockfile-cleanup.yml
@@ -27,4 +27,4 @@ jobs:
           npx --no-install prepare-package-lock
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git diff --quiet || (git add package-lock.json && git commit -m "chore: remove @cloudscape-design deps from lockfile" && git push)
+          git diff --quiet || (git add package-lock.json && git commit --no-verify -m "chore: remove @cloudscape-design deps from lockfile" && git push)


### PR DESCRIPTION
A follow-up for https://github.com/cloudscape-design/actions/pull/116.

The cleanup action failed (https://github.com/cloudscape-design/components/actions/runs/25104690267/job/73736713219) with:
```
git-secrets is not installed. Please run 'brew install git-secrets' or visit https://github.com/awslabs/git-secrets#installing-git-secrets
husky - pre-commit script failed (code 1)
Error: Process completed with exit code 1.
```

The PR should fix that by ignoring git-scripts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
