### PR TITLE
fix: Disables husky in dependabot cleanup action

### DIFF
--- a/.github/workflows/dependabot-lockfile-cleanup.yml
+++ b/.github/workflows/dependabot-lockfile-cleanup.yml
@@ -27,4 +27,6 @@ jobs:
           npx --no-install prepare-package-lock
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git diff --quiet || (git add package-lock.json && git commit --no-verify -m "chore: remove @cloudscape-design deps from lockfile" && git push)
+          git diff --quiet || (git add package-lock.json && git commit -m "chore: remove @cloudscape-design deps from lockfile" && git push)
+        env:
+          HUSKY: "0"


### PR DESCRIPTION
The fix should address this failure: https://github.com/cloudscape-design/components/actions/runs/25510452508/job/74867501016

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
