### PR TITLE
feat: deploy dev pages preview for fork pull requests

### DIFF
--- a/.github/actions/deploy-static/action.yml
+++ b/.github/actions/deploy-static/action.yml
@@ -14,6 +14,10 @@ inputs:
   target-path:
     description: Path prefix on the deployment URL
     required: true
+  commit-sha:
+    description: Commit SHA used in the deployment path
+    required: false
+    default: ${{ github.event.pull_request.head.sha }}
 
 outputs:
   preview-url:
@@ -32,7 +36,7 @@ runs:
       id: deployment-path
       shell: bash
       run: |
-        echo "deployment-path=${{ github.event.repository.name }}/${{ github.event.pull_request.head.sha }}/${{ inputs.target-path }}/" >> $GITHUB_OUTPUT
+        echo "deployment-path=${{ github.event.repository.name }}/${{ inputs.commit-sha }}/${{ inputs.target-path }}/" >> $GITHUB_OUTPUT
     - name: Deploy content
       id: deploy
       shell: bash

--- a/.github/actions/deploy-static/action.yml
+++ b/.github/actions/deploy-static/action.yml
@@ -41,4 +41,4 @@ runs:
       id: deploy
       shell: bash
       run: |
-        aws s3 cp ${{ inputs.source-path }} s3://${{ inputs.deployment-bucket }}/${{ steps.deployment-path.outputs.deployment-path }} --recursive
+        aws s3 cp ${{ inputs.source-path }} s3://${{ inputs.deployment-bucket }}/${{ steps.deployment-path.outputs.deployment-path }} --recursive --no-follow-symlinks

--- a/.github/workflows/deploy-fork-preview.yml
+++ b/.github/workflows/deploy-fork-preview.yml
@@ -1,31 +1,29 @@
-name: Deploy
+name: Deploy fork preview
 
 on:
   workflow_call:
     inputs:
       artifact-name:
+        description: Artifact to download/deploy; also the target path and the `fork-` environment suffix
         type: string
-        description: Name of artifact to deploy
         required: true
-      deployment-path:
-        type: string
-        description: Directory of assets to upload
-        default: '.'
 
 permissions:
   id-token: write
   contents: read
   deployments: write
+  actions: read
 
 jobs:
   deploy:
     if: >
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name != github.event.workflow_run.repository.full_name }}
     runs-on: ubuntu-latest
     continue-on-error: true
     environment:
-      name: ${{ inputs.artifact-name }}
+      name: fork-${{ inputs.artifact-name }}
       url: ${{ steps.deploy.outputs.preview-url }}index.html
     steps:
       - name: Download artifact
@@ -33,6 +31,8 @@ jobs:
         with:
           name: ${{ inputs.artifact-name }}
           path: build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
       - name: Deploy dev-pages
         id: deploy
         uses: cloudscape-design/actions/.github/actions/deploy-static@main
@@ -41,3 +41,4 @@ jobs:
           deployment-bucket: ${{ secrets.AWS_PREVIEW_BUCKET_NAME }}
           source-path: build
           target-path: ${{ inputs.artifact-name }}
+          commit-sha: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
*Description of changes:*
Forked-PR workflows run without secrets, so they can't deploy previews. Add a workflow_run-based privileged deploy that runs after the build, behind the existing environment approval gate, so a maintainer can approve and publish a fork's dev-pages preview.

**Merging this PR won't make it automatically deploy the dev pages**. It needs to be added to each repository for example for board-components [example draft PR](https://github.com/cloudscape-design/board-components/pull/442)

**Approach:**
- The build stays on **pull_request** (unprivileged, no secrets) and uploads the dev-pages artifact this already works for forks.
- A new `workflow_run` triggered deploy runs after the build, from the default branch, with secrets, and never checks out or runs fork code. It only downloads the prebuilt artifact and uploads it via the existing deploy-static action.

**How consuming repos use it**
Each repo does two small things: let its build run for forks (so the artifact is produced), and add a tiny workflow_run wrapper that calls this reusable workflow. The wrapper is the only new per-repo file (workflow_run must live in the same repo).

for example for board-components [example draft PR](https://github.com/cloudscape-design/board-components/pull/442)

*Issue #, if available:* AWSUI-53554

I tested it here on a [personal repository](https://github.com/amanabiy/fork-contribution-setup). [Here](https://github.com/amanabiy/fork-contribution-setup/actions/runs/28391316362) is an example of a deploy that requires approval.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
