### PR TITLE
chore: Fixes dry run for build tools

### DIFF
--- a/.github/actions/build-repository/action.yml
+++ b/.github/actions/build-repository/action.yml
@@ -63,6 +63,7 @@ runs:
       uses: cloudscape-design/actions/.github/actions/patch-local-dependencies@main
       with:
         path: ${{ github.workspace }}
+        build-tools-ref: ${{ github.repository == 'cloudscape-design/build-tools' && github.head_ref || '' }}
 
     - name: Unlock dependencies
       uses: cloudscape-design/actions/.github/actions/unlock-dependencies@main

--- a/.github/actions/patch-local-dependencies/action.yml
+++ b/.github/actions/patch-local-dependencies/action.yml
@@ -8,6 +8,12 @@ inputs:
     description: Path to the directory containing the local tarballs
     required: true
     default: './.build-cache'
+  build-tools-ref:
+    description: >-
+      Git ref (branch or SHA) to install @cloudscape-design/build-tools from during a dry-run.
+      Set only when the dry-run source repository is build-tools; leave empty otherwise.
+    required: false
+    default: ''
 runs:
   using: 'node20'
   main: 'index.js'

--- a/.github/actions/patch-local-dependencies/index.js
+++ b/.github/actions/patch-local-dependencies/index.js
@@ -8,25 +8,24 @@ const core = require('./core');
 
 const rootPath = core.getInput('path');
 const tarballDir = core.getInput('tarball-dir');
+const buildToolsRef = core.getInput('build-tools-ref');
 
 const packageJsonFullPath = path.resolve(path.join(rootPath, 'package.json'));
 const tarballDirFullPath = path.resolve(tarballDir);
-
-if (!fs.existsSync(tarballDirFullPath)) {
-  console.log('No local tarball directory found. No local dependencies will be loaded.');
-  return;
-}
 
 if (!fs.existsSync(packageJsonFullPath)) {
   throw new Error(`package.json not found at path: ${packageJsonFullPath}`);
 }
 
 const packageJsonData = JSON.parse(fs.readFileSync(packageJsonFullPath, 'utf8'));
-const tarballFiles = fs.readdirSync(tarballDirFullPath).filter(file => file.endsWith('.tgz'));
+const tarballFiles = fs.existsSync(tarballDirFullPath)
+  ? fs.readdirSync(tarballDirFullPath).filter(file => file.endsWith('.tgz'))
+  : [];
 
 const updateCloudscapeDependencies = dependencies => {
   if (!dependencies) return {};
-  return Object.keys(dependencies).reduce((updatedDeps, key) => {
+
+  dependencies = Object.keys(dependencies).reduce((updatedDeps, key) => {
     if (key.startsWith('@cloudscape-design/')) {
       const tarball = tarballFiles.find(file => file.replace('cloudscape-design-', '').startsWith(key.replace('@cloudscape-design/', '')));
       if (tarball) {
@@ -41,6 +40,17 @@ const updateCloudscapeDependencies = dependencies => {
     }
     return updatedDeps;
   }, {});
+
+  // build-tools is consumed via a `github:` reference (it ships no build artifact / tarball),
+  // so it can't be swapped in through the tarball mechanism above. When the dry-run originates
+  // from a build-tools PR, re-point that reference at the branch/SHA under test so downstream
+  // packages install the PR version instead of `#main`.
+  if (buildToolsRef && dependencies['@cloudscape-design/build-tools']) {
+    console.log(`Updating @cloudscape-design/build-tools to dry-run ref: ${buildToolsRef}`);
+    dependencies['@cloudscape-design/build-tools'] = `github:cloudscape-design/build-tools#${buildToolsRef}`;
+  }
+
+  return dependencies;
 };
 
 packageJsonData.dependencies = updateCloudscapeDependencies(packageJsonData.dependencies);


### PR DESCRIPTION
The build tools dependency is installed directly from GitHub, thus the existing dry-run mechanism did not apply. As result, the dry-run job of build tools used the mainline version instead of the branch version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
