### PR TITLE
fix: pin changed package's git-URL deps to the PR commit in dry-run

### DIFF
--- a/.github/actions/create-build-tree/generated/dependencies.json
+++ b/.github/actions/create-build-tree/generated/dependencies.json
@@ -2,11 +2,16 @@
   "cloudscape-design/global-styles": [],
   "cloudscape-design/documenter": [],
   "cloudscape-design/jest-preset": [],
-  "cloudscape-design/collection-hooks": [],
+  "cloudscape-design/collection-hooks": [
+    "cloudscape-design/component-toolkit",
+    "cloudscape-design/build-tools"
+  ],
   "cloudscape-design/test-utils": [
-    "cloudscape-design/documenter"
+    "cloudscape-design/documenter",
+    "cloudscape-design/build-tools"
   ],
   "cloudscape-design/theming-core": [
+    "cloudscape-design/build-tools",
     "cloudscape-design/browser-test-tools",
     "cloudscape-design/component-toolkit"
   ],
@@ -19,7 +24,6 @@
     "cloudscape-design/browser-test-tools",
     "cloudscape-design/build-tools",
     "cloudscape-design/documenter",
-    "cloudscape-design/eslint-plugin",
     "cloudscape-design/global-styles",
     "cloudscape-design/jest-preset",
     "cloudscape-design/test-utils-converter",
@@ -39,14 +43,16 @@
   ],
   "cloudscape-design/component-toolkit": [
     "cloudscape-design/browser-test-tools",
+    "cloudscape-design/build-tools",
     "cloudscape-design/jest-preset"
   ],
   "cloudscape-design/demos": [
+    "cloudscape-design/build-tools",
     "cloudscape-design/board-components",
     "cloudscape-design/browser-test-tools",
-    "cloudscape-design/code-view",
-    "cloudscape-design/chat-components",
     "cloudscape-design/chart-components",
+    "cloudscape-design/chat-components",
+    "cloudscape-design/code-view",
     "cloudscape-design/collection-hooks",
     "cloudscape-design/component-toolkit",
     "cloudscape-design/components",
@@ -71,6 +77,7 @@
     "cloudscape-design/test-utils-core",
     "cloudscape-design/browser-test-tools",
     "cloudscape-design/build-tools",
+    "cloudscape-design/code-view",
     "cloudscape-design/components",
     "cloudscape-design/design-tokens",
     "cloudscape-design/documenter",
@@ -78,17 +85,18 @@
     "cloudscape-design/test-utils-converter",
     "cloudscape-design/theming-build"
   ],
+  "cloudscape-design/build-tools": [],
   "cloudscape-design/chart-components": [
     "cloudscape-design/component-toolkit",
-    "cloudscape-design/test-utils-core",
     "cloudscape-design/browser-test-tools",
     "cloudscape-design/build-tools",
+    "cloudscape-design/code-view",
     "cloudscape-design/components",
     "cloudscape-design/design-tokens",
     "cloudscape-design/documenter",
     "cloudscape-design/global-styles",
     "cloudscape-design/test-utils-converter",
+    "cloudscape-design/test-utils-core",
     "cloudscape-design/theming-build"
-  ],
-  "cloudscape-design/build-tools": []
+  ]
 }

--- a/.github/actions/create-build-tree/generated/dependents.json
+++ b/.github/actions/create-build-tree/generated/dependents.json
@@ -1,4 +1,26 @@
 {
+  "cloudscape-design/component-toolkit": [
+    "cloudscape-design/collection-hooks",
+    "cloudscape-design/theming-core",
+    "cloudscape-design/components",
+    "cloudscape-design/board-components",
+    "cloudscape-design/demos",
+    "cloudscape-design/code-view",
+    "cloudscape-design/chat-components",
+    "cloudscape-design/chart-components"
+  ],
+  "cloudscape-design/build-tools": [
+    "cloudscape-design/collection-hooks",
+    "cloudscape-design/test-utils",
+    "cloudscape-design/theming-core",
+    "cloudscape-design/components",
+    "cloudscape-design/board-components",
+    "cloudscape-design/component-toolkit",
+    "cloudscape-design/demos",
+    "cloudscape-design/code-view",
+    "cloudscape-design/chat-components",
+    "cloudscape-design/chart-components"
+  ],
   "cloudscape-design/documenter": [
     "cloudscape-design/test-utils",
     "cloudscape-design/components",
@@ -12,15 +34,6 @@
     "cloudscape-design/components",
     "cloudscape-design/board-components",
     "cloudscape-design/component-toolkit",
-    "cloudscape-design/demos",
-    "cloudscape-design/code-view",
-    "cloudscape-design/chat-components",
-    "cloudscape-design/chart-components"
-  ],
-  "cloudscape-design/component-toolkit": [
-    "cloudscape-design/theming-core",
-    "cloudscape-design/components",
-    "cloudscape-design/board-components",
     "cloudscape-design/demos",
     "cloudscape-design/code-view",
     "cloudscape-design/chat-components",
@@ -40,16 +53,6 @@
   "cloudscape-design/theming-runtime": [
     "cloudscape-design/components",
     "cloudscape-design/demos"
-  ],
-  "cloudscape-design/build-tools": [
-    "cloudscape-design/components",
-    "cloudscape-design/board-components",
-    "cloudscape-design/code-view",
-    "cloudscape-design/chat-components",
-    "cloudscape-design/chart-components"
-  ],
-  "cloudscape-design/eslint-plugin": [
-    "cloudscape-design/components"
   ],
   "cloudscape-design/global-styles": [
     "cloudscape-design/components",
@@ -94,13 +97,15 @@
   "cloudscape-design/board-components": [
     "cloudscape-design/demos"
   ],
-  "cloudscape-design/code-view": [
+  "cloudscape-design/chart-components": [
     "cloudscape-design/demos"
   ],
   "cloudscape-design/chat-components": [
     "cloudscape-design/demos"
   ],
-  "cloudscape-design/chart-components": [
-    "cloudscape-design/demos"
+  "cloudscape-design/code-view": [
+    "cloudscape-design/demos",
+    "cloudscape-design/chat-components",
+    "cloudscape-design/chart-components"
   ]
 }

--- a/.github/actions/patch-local-dependencies/index.js
+++ b/.github/actions/patch-local-dependencies/index.js
@@ -12,17 +12,17 @@ const tarballDir = core.getInput('tarball-dir');
 const packageJsonFullPath = path.resolve(path.join(rootPath, 'package.json'));
 const tarballDirFullPath = path.resolve(tarballDir);
 
-if (!fs.existsSync(tarballDirFullPath)) {
-  console.log('No local tarball directory found. No local dependencies will be loaded.');
-  return;
-}
-
 if (!fs.existsSync(packageJsonFullPath)) {
   throw new Error(`package.json not found at path: ${packageJsonFullPath}`);
 }
 
+const tarballDirExists = fs.existsSync(tarballDirFullPath);
+if (!tarballDirExists) {
+  console.log('No local tarball directory found; only git-ref repinning of the changed package will apply.');
+}
+
 const packageJsonData = JSON.parse(fs.readFileSync(packageJsonFullPath, 'utf8'));
-const tarballFiles = fs.readdirSync(tarballDirFullPath).filter(file => file.endsWith('.tgz'));
+const tarballFiles = tarballDirExists ? fs.readdirSync(tarballDirFullPath).filter(file => file.endsWith('.tgz')) : [];
 
 // The package under test in a dry-run, and the commit to pin it to. When a
 // consumer references the changed package via a `github:<repo>#<ref>` git URL

--- a/.github/actions/patch-local-dependencies/index.js
+++ b/.github/actions/patch-local-dependencies/index.js
@@ -24,6 +24,20 @@ if (!fs.existsSync(packageJsonFullPath)) {
 const packageJsonData = JSON.parse(fs.readFileSync(packageJsonFullPath, 'utf8'));
 const tarballFiles = fs.readdirSync(tarballDirFullPath).filter(file => file.endsWith('.tgz'));
 
+// The package under test in a dry-run, and the commit to pin it to. When a
+// consumer references the changed package via a `github:<repo>#<ref>` git URL
+// (e.g. build-tools, which publishes no tarball), swap the ref to the PR commit
+// so the consumer resolves against the PR's manifest instead of live main.
+const changedRepo = process.env.DRY_RUN_CHANGED_REPO || '';
+const changedRef = process.env.DRY_RUN_CHANGED_SHA || '';
+
+const repinGitRefToChangedCommit = value => {
+  if (!changedRepo || !changedRef) return null;
+  const match = /^github:([^#]+)(?:#.*)?$/.exec(value);
+  if (!match || match[1] !== changedRepo) return null;
+  return `github:${changedRepo}#${changedRef}`;
+};
+
 const updateCloudscapeDependencies = dependencies => {
   if (!dependencies) return {};
   return Object.keys(dependencies).reduce((updatedDeps, key) => {
@@ -33,8 +47,14 @@ const updateCloudscapeDependencies = dependencies => {
         console.log(`Updating ${key} to tarball file: ${tarball}`);
         updatedDeps[key] = `file:${path.join(tarballDirFullPath, tarball)}`;
       } else {
-        console.log(`No tarball found for ${key}, skipping update.`);
-        updatedDeps[key] = dependencies[key];
+        const repinned = repinGitRefToChangedCommit(dependencies[key]);
+        if (repinned) {
+          console.log(`Pinning ${key} git ref to changed commit: ${repinned}`);
+          updatedDeps[key] = repinned;
+        } else {
+          console.log(`No tarball found for ${key}, skipping update.`);
+          updatedDeps[key] = dependencies[key];
+        }
       }
     } else {
       updatedDeps[key] = dependencies[key];

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -24,6 +24,11 @@ env:
   # Disable Husky in CI
   # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
   HUSKY: 0
+  # Identify the package under test and the PR commit, so consumers that
+  # reference it via a `github:<repo>#<ref>` git URL (which produces no tarball)
+  # are repinned to the PR commit instead of resolving against live main.
+  DRY_RUN_CHANGED_REPO: ${{ github.repository }}
+  DRY_RUN_CHANGED_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
 
 jobs:
   createBuildTree:


### PR DESCRIPTION
## Description
Closes two coverage gaps in the dry-run that let a build-tools peer-range regression (build-tools#55) reach the merge queue undetected. The two fixes are complementary — one fixes *which* consumers get tested, the other fixes *how faithfully* they're tested.

### 1. Repin the changed package's git-URL deps to the PR commit
`patch-local-dependencies` only swapped `@cloudscape-design/*` deps that have a local tarball. Packages consumed via a `github:<repo>#<ref>` git URL and publishing no tarball (e.g. build-tools) were left on `#main`, so consumers resolved the changed package from live `main` instead of the PR — the dry-run never saw the PR's manifest. Now, when no tarball exists, a `github:<changed-repo>#…` dep is repinned to the PR commit so consumers install the PR's manifest via the same git-dep mechanism production uses. Also fixed an early-return that skipped the repin entirely when no `.build-cache` dir was present (the build-tools case). `DRY_RUN_CHANGED_SHA` resolves to the PR head (`pull_request`) or merge-group head (`merge_group`); other contexts leave it empty (no-op).

### 2. Regenerate the stale dependency graph
`create-build-tree/generated/dependents.json` had gone stale: build-tools listed only the components family, so collection-hooks / component-toolkit / test-utils / theming-core were skipped in build-tools dry-runs entirely. Regenerated from current package.json manifests via `generate-dependencies.js` so build-tools fans out to all real consumers.

## How has this been tested?
Unit-tested the repin predicate; `node --check` on the action. End-to-end validated via a throwaway build-tools PR that reintroduces a bad `react-router-dom>=6` peer against a self-test branch (nested action refs repointed): consumers now repin to the PR build-tools and ERESOLVE as designed, whereas against `main` today they stay green.

## Notes
- `dependents.json` is a committed snapshot and will drift again; a scheduled regeneration or drift-guard is a recommended follow-up (needs a PR-creating token / repo conventions to confirm).
- `@octokit/rest` is only a devDependency, so runtime graph generation isn't viable without bundling — the committed-snapshot + offline-regen model is retained.
