### PR TITLE
fix: regenerate dependents.json so build-tools dry-run covers all consumers

### DIFF
--- a/.github/actions/create-build-tree/generated/dependencies.json
+++ b/.github/actions/create-build-tree/generated/dependencies.json
@@ -2,11 +2,16 @@
   "cloudscape-design/global-styles": [],
   "cloudscape-design/documenter": [],
   "cloudscape-design/jest-preset": [],
-  "cloudscape-design/collection-hooks": [],
+  "cloudscape-design/collection-hooks": [
+    "cloudscape-design/component-toolkit",
+    "cloudscape-design/build-tools"
+  ],
   "cloudscape-design/test-utils": [
-    "cloudscape-design/documenter"
+    "cloudscape-design/documenter",
+    "cloudscape-design/build-tools"
   ],
   "cloudscape-design/theming-core": [
+    "cloudscape-design/build-tools",
     "cloudscape-design/browser-test-tools",
     "cloudscape-design/component-toolkit"
   ],
@@ -19,7 +24,6 @@
     "cloudscape-design/browser-test-tools",
     "cloudscape-design/build-tools",
     "cloudscape-design/documenter",
-    "cloudscape-design/eslint-plugin",
     "cloudscape-design/global-styles",
     "cloudscape-design/jest-preset",
     "cloudscape-design/test-utils-converter",
@@ -39,14 +43,16 @@
   ],
   "cloudscape-design/component-toolkit": [
     "cloudscape-design/browser-test-tools",
+    "cloudscape-design/build-tools",
     "cloudscape-design/jest-preset"
   ],
   "cloudscape-design/demos": [
+    "cloudscape-design/build-tools",
     "cloudscape-design/board-components",
     "cloudscape-design/browser-test-tools",
-    "cloudscape-design/code-view",
-    "cloudscape-design/chat-components",
     "cloudscape-design/chart-components",
+    "cloudscape-design/chat-components",
+    "cloudscape-design/code-view",
     "cloudscape-design/collection-hooks",
     "cloudscape-design/component-toolkit",
     "cloudscape-design/components",
@@ -71,6 +77,7 @@
     "cloudscape-design/test-utils-core",
     "cloudscape-design/browser-test-tools",
     "cloudscape-design/build-tools",
+    "cloudscape-design/code-view",
     "cloudscape-design/components",
     "cloudscape-design/design-tokens",
     "cloudscape-design/documenter",
@@ -78,17 +85,18 @@
     "cloudscape-design/test-utils-converter",
     "cloudscape-design/theming-build"
   ],
+  "cloudscape-design/build-tools": [],
   "cloudscape-design/chart-components": [
     "cloudscape-design/component-toolkit",
-    "cloudscape-design/test-utils-core",
     "cloudscape-design/browser-test-tools",
     "cloudscape-design/build-tools",
+    "cloudscape-design/code-view",
     "cloudscape-design/components",
     "cloudscape-design/design-tokens",
     "cloudscape-design/documenter",
     "cloudscape-design/global-styles",
     "cloudscape-design/test-utils-converter",
+    "cloudscape-design/test-utils-core",
     "cloudscape-design/theming-build"
-  ],
-  "cloudscape-design/build-tools": []
+  ]
 }

--- a/.github/actions/create-build-tree/generated/dependents.json
+++ b/.github/actions/create-build-tree/generated/dependents.json
@@ -1,4 +1,26 @@
 {
+  "cloudscape-design/component-toolkit": [
+    "cloudscape-design/collection-hooks",
+    "cloudscape-design/theming-core",
+    "cloudscape-design/components",
+    "cloudscape-design/board-components",
+    "cloudscape-design/demos",
+    "cloudscape-design/code-view",
+    "cloudscape-design/chat-components",
+    "cloudscape-design/chart-components"
+  ],
+  "cloudscape-design/build-tools": [
+    "cloudscape-design/collection-hooks",
+    "cloudscape-design/test-utils",
+    "cloudscape-design/theming-core",
+    "cloudscape-design/components",
+    "cloudscape-design/board-components",
+    "cloudscape-design/component-toolkit",
+    "cloudscape-design/demos",
+    "cloudscape-design/code-view",
+    "cloudscape-design/chat-components",
+    "cloudscape-design/chart-components"
+  ],
   "cloudscape-design/documenter": [
     "cloudscape-design/test-utils",
     "cloudscape-design/components",
@@ -12,15 +34,6 @@
     "cloudscape-design/components",
     "cloudscape-design/board-components",
     "cloudscape-design/component-toolkit",
-    "cloudscape-design/demos",
-    "cloudscape-design/code-view",
-    "cloudscape-design/chat-components",
-    "cloudscape-design/chart-components"
-  ],
-  "cloudscape-design/component-toolkit": [
-    "cloudscape-design/theming-core",
-    "cloudscape-design/components",
-    "cloudscape-design/board-components",
     "cloudscape-design/demos",
     "cloudscape-design/code-view",
     "cloudscape-design/chat-components",
@@ -40,16 +53,6 @@
   "cloudscape-design/theming-runtime": [
     "cloudscape-design/components",
     "cloudscape-design/demos"
-  ],
-  "cloudscape-design/build-tools": [
-    "cloudscape-design/components",
-    "cloudscape-design/board-components",
-    "cloudscape-design/code-view",
-    "cloudscape-design/chat-components",
-    "cloudscape-design/chart-components"
-  ],
-  "cloudscape-design/eslint-plugin": [
-    "cloudscape-design/components"
   ],
   "cloudscape-design/global-styles": [
     "cloudscape-design/components",
@@ -94,13 +97,15 @@
   "cloudscape-design/board-components": [
     "cloudscape-design/demos"
   ],
-  "cloudscape-design/code-view": [
+  "cloudscape-design/chart-components": [
     "cloudscape-design/demos"
   ],
   "cloudscape-design/chat-components": [
     "cloudscape-design/demos"
   ],
-  "cloudscape-design/chart-components": [
-    "cloudscape-design/demos"
+  "cloudscape-design/code-view": [
+    "cloudscape-design/demos",
+    "cloudscape-design/chat-components",
+    "cloudscape-design/chart-components"
   ]
 }


### PR DESCRIPTION
## Description
Regenerates the committed `create-build-tree/generated/dependents.json` (and `dependencies.json`), which had gone stale. build-tools listed only the components family as dependents, so collection-hooks / component-toolkit / test-utils / theming-core were skipped entirely in build-tools dry-runs — their `build-repository` jobs never ran. Regenerated from current package.json manifests via `generate-dependencies.js` so build-tools fans out to all real consumers.

Complements the repin fix in #123: #123 makes the consumers that *do* run resolve the changed package faithfully; this makes sure the right consumers run at all.

## How has this been tested?
`node generate-dependencies.js` against current org manifests; verified build-tools now includes collection-hooks/test-utils/theming-core/component-toolkit/demos. Only the generated JSON changed.

## Note
This is a committed snapshot and will drift again as repos add deps; a scheduled regeneration or drift-guard would prevent recurrence (follow-up).
