### PR TITLE
fix: attach fork deployments to pull requests

### DIFF
--- a/.github/workflows/deploy-fork-preview.yml
+++ b/.github/workflows/deploy-fork-preview.yml
@@ -22,9 +22,6 @@ jobs:
       github.event.workflow_run.head_repository.full_name != github.event.workflow_run.repository.full_name }}
     runs-on: ubuntu-latest
     continue-on-error: true
-    environment:
-      name: fork-${{ inputs.artifact-name }}
-      url: ${{ steps.deploy.outputs.preview-url }}index.html
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -42,3 +39,26 @@ jobs:
           source-path: build
           target-path: ${{ inputs.artifact-name }}
           commit-sha: ${{ github.event.workflow_run.head_sha }}
+      - name: Attach deployment to pull request
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ENVIRONMENT: fork-${{ inputs.artifact-name }}
+          ENVIRONMENT_URL: ${{ steps.deploy.outputs.preview-url }}index.html
+        with:
+          script: |
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.workflow_run.head_sha,
+              environment: process.env.DEPLOYMENT_ENVIRONMENT,
+              auto_merge: false,
+              required_contexts: [],
+            });
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: 'success',
+              environment_url: process.env.ENVIRONMENT_URL,
+            });

--- a/.github/workflows/deploy-fork-preview.yml
+++ b/.github/workflows/deploy-fork-preview.yml
@@ -39,6 +39,7 @@ jobs:
           source-path: build
           target-path: ${{ inputs.artifact-name }}
           commit-sha: ${{ github.event.workflow_run.head_sha }}
+      # workflow_run uses the default branch ref, so explicitly attach the deployment to the fork PR commit
       - name: Attach deployment to pull request
         uses: actions/github-script@v7
         env:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Replace the automatic environment deployment with an explicit deployment associated with the fork PR’s head commit. This makes the preview URL visible directly on the pull request instead of only in the Actions workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
