### PR TITLE
chore: add comment to deploying fork prs

### DIFF
--- a/.github/workflows/deploy-fork-preview.yml
+++ b/.github/workflows/deploy-fork-preview.yml
@@ -1,6 +1,12 @@
 name: Deploy fork preview
 
 on:
+  # Fork preview flow:
+  # 1. After reviewing the fork changes, a maintainer approves the pull_request workflow run.
+  # 2. The consumer's pull_request workflow calls the shared build-lint-test.yml workflow.
+  #    It runs without secrets and uploads the preview artifact.
+  # 3. After the build succeeds, a workflow_run wrapper in the consuming repository calls this workflow.
+  # 4. This privileged workflow downloads and deploys the artifact without checking out or running fork code.
   workflow_call:
     inputs:
       artifact-name:
@@ -22,12 +28,16 @@ jobs:
       github.event.workflow_run.head_repository.full_name != github.event.workflow_run.repository.full_name }}
     runs-on: ubuntu-latest
     continue-on-error: true
+    # workflow_run loads this workflow from the default branch, so the fork cannot alter privileged steps.
+    # This job must never check out or execute fork code; it only deploys the artifact built without secrets.
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
           path: build
+          # The artifact belongs to the triggering build run, so fetch it using the run ID from
+          # the caller's workflow_run payload. Cross-run downloads require the token and actions: read.
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
       - name: Deploy dev-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,8 @@ permissions:
   deployments: write
 
 jobs:
-  # This path is for internal PRs only. Fork PRs do not receive secrets and use
+  # This path is for internal PRs only. Fork PRs do not receive secrets; they use
+  # the deploy-fork-preview.yml workflow instead.
   deploy:
     if: >
       github.event_name == 'pull_request' &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ permissions:
   deployments: write
 
 jobs:
+  # This path is for internal PRs only. Fork PRs do not receive secrets and use
   deploy:
     if: >
       github.event_name == 'pull_request' &&


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds inline comments documenting the fork preview deployment flow, including maintainer approval, the unprivileged build-lint-test.yml build, the workflow_run handoff, and the privileged artifact-only deployment. 


No workflow behavior changes.

Follow up of https://github.com/cloudscape-design/actions/pull/122

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
