### PR TITLE
fix: install build-tools from the head repository in fork dry-runs

### DIFF
--- a/.github/actions/build-repository/action.yml
+++ b/.github/actions/build-repository/action.yml
@@ -64,6 +64,7 @@ runs:
       with:
         path: ${{ github.workspace }}
         build-tools-ref: ${{ github.repository == 'cloudscape-design/build-tools' && github.head_ref || '' }}
+        build-tools-repository: ${{ github.repository == 'cloudscape-design/build-tools' && github.event.pull_request.head.repo.full_name || '' }}
 
     - name: Unlock dependencies
       uses: cloudscape-design/actions/.github/actions/unlock-dependencies@main

--- a/.github/actions/patch-local-dependencies/action.yml
+++ b/.github/actions/patch-local-dependencies/action.yml
@@ -14,6 +14,13 @@ inputs:
       Set only when the dry-run source repository is build-tools; leave empty otherwise.
     required: false
     default: ''
+  build-tools-repository:
+    description: >-
+      Repository to install @cloudscape-design/build-tools from during a dry-run. Set it to the
+      pull request's head repository so that dry-runs of forked pull requests resolve, as their
+      branches only exist in the fork. Defaults to the upstream repository when empty.
+    required: false
+    default: 'cloudscape-design/build-tools'
 runs:
   using: 'node20'
   main: 'index.js'

--- a/.github/actions/patch-local-dependencies/index.js
+++ b/.github/actions/patch-local-dependencies/index.js
@@ -9,6 +9,7 @@ const core = require('./core');
 const rootPath = core.getInput('path');
 const tarballDir = core.getInput('tarball-dir');
 const buildToolsRef = core.getInput('build-tools-ref');
+const buildToolsRepository = core.getInput('build-tools-repository') || 'cloudscape-design/build-tools';
 
 const packageJsonFullPath = path.resolve(path.join(rootPath, 'package.json'));
 const tarballDirFullPath = path.resolve(tarballDir);
@@ -43,11 +44,13 @@ const updateCloudscapeDependencies = dependencies => {
 
   // build-tools is consumed via a `github:` reference (it ships no build artifact / tarball),
   // so it can't be swapped in through the tarball mechanism above. When the dry-run originates
-  // from a build-tools PR, re-point that reference at the branch/SHA under test so downstream
-  // packages install the PR version instead of `#main`.
+  // from a build-tools PR, re-point that reference at the repository and branch/SHA under test so
+  // downstream packages install the PR version instead of `#main`. The repository matters because
+  // a forked pull request's branch does not exist in the upstream repository.
   if (buildToolsRef && dependencies['@cloudscape-design/build-tools']) {
-    console.log(`Updating @cloudscape-design/build-tools to dry-run ref: ${buildToolsRef}`);
-    dependencies['@cloudscape-design/build-tools'] = `github:cloudscape-design/build-tools#${buildToolsRef}`;
+    const buildToolsReference = `github:${buildToolsRepository}#${buildToolsRef}`;
+    console.log(`Updating @cloudscape-design/build-tools to dry-run ref: ${buildToolsReference}`);
+    dependencies['@cloudscape-design/build-tools'] = buildToolsReference;
   }
 
   return dependencies;


### PR DESCRIPTION
## Description

Dry-runs of build-tools pull requests re-point the `@cloudscape-design/build-tools` dependency at the branch under test, but the reference hardcodes the upstream repository:

```js
dependencies['@cloudscape-design/build-tools'] = `github:cloudscape-design/build-tools#${buildToolsRef}`;
```

For a pull request from a fork, `github.repository` is still the base repository, so the condition in `build-repository/action.yml` is true while `github.head_ref` names a branch that exists only in the fork. Every downstream job then fails during `npm install`:

```
npm error The git reference could not be found
npm error command git --no-replace-objects checkout <branch>
npm error error: pathspec '<branch>' did not match any file(s) known to git
```

This adds a `build-tools-repository` input and interpolates it into the reference. `build-repository` passes the pull request's head repository, which is the base repository for same-repo pull requests and the fork for forked ones. The input defaults to `cloudscape-design/build-tools`, and the script falls back to the same value when it is empty, so nothing changes for same-repo pull requests, the merge queue, or dry-runs that do not originate from build-tools.

The behaviour was introduced in #123. It currently blocks cloudscape-design/build-tools#75, the first fork pull request to build-tools since then, where all three dry-run jobs fail this way and the rest of the chain is skipped.

## How has this been tested?

Ran `index.js` against a `package.json` fixture across the input combinations:

| `build-tools-ref` | `build-tools-repository` | resulting reference |
| --- | --- | --- |
| `feat-lh` | `TrevorBurnham/build-tools` | `github:TrevorBurnham/build-tools#feat-lh` |
| `feat-lh` | `cloudscape-design/build-tools` | `github:cloudscape-design/build-tools#feat-lh` |
| `feat-lh` | empty | `github:cloudscape-design/build-tools#feat-lh` |
| `feat-lh` | unset | `github:cloudscape-design/build-tools#feat-lh` |
| empty | any | unchanged (`#main`) |

Confirmed that tarball substitution for the other `@cloudscape-design/*` dependencies still applies alongside the build-tools reference.

Reproduced the failure and verified the fix with npm directly: installing `github:cloudscape-design/build-tools#feat-license-headers-line-comments` produces the CI error verbatim, while `github:TrevorBurnham/build-tools#feat-license-headers-line-comments` installs successfully and the resulting package contains the branch's changes.
